### PR TITLE
CH-05 Create summary section

### DIFF
--- a/app/checkout/[checkoutId]/page.tsx
+++ b/app/checkout/[checkoutId]/page.tsx
@@ -2,8 +2,7 @@ import React from "react";
 
 import { Checkout, CheckoutDocument } from "@/generated/graphql";
 import { getClient } from "@/lib/ApolloClient";
-import { ContactDetails } from "@/sections";
-import { ShippingAddress } from "@/sections/ShippingAddress/ShippingAddress";
+import { ContactDetails, ShippingAddress, Summary } from "@/sections";
 
 interface CheckoutPageProps {
   params: {
@@ -31,7 +30,7 @@ const CheckoutPage = async ({ params: { checkoutId } }: CheckoutPageProps) => {
           <ContactDetails checkoutData={checkoutData} />
           <ShippingAddress checkoutData={checkoutData} />
         </div>
-        <div className="mb-5 h-[280px] w-full max-w-full bg-lightGray md:max-w-xs">Summary</div>
+        <Summary checkoutData={checkoutData} />
       </div>
     </main>
   );

--- a/graphql/queries/Checkout.graphql
+++ b/graphql/queries/Checkout.graphql
@@ -29,5 +29,45 @@ query Checkout($id: ID, $token: UUID) {
       }
       countryArea
     }
+    lines {
+      quantity
+      variant {
+        product {
+          attributes {
+            attribute {
+              name
+            }
+          }
+        }
+        media {
+          url
+        }
+      }
+      totalPrice {
+        currency
+        net {
+          currency
+          amount
+        }
+      }
+    }
+    shippingMethods {
+      id
+      name
+      price {
+        currency
+        amount
+      }
+    }
+    totalPrice {
+      tax {
+        currency
+        amount
+      }
+      gross {
+        currency
+        amount
+      }
+    }
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
 
-module.exports = nextConfig
+module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "damian-lis.eu.saleor.cloud",
+        port: "",
+        pathname: "/media/thumbnails/products/**",
+      },
+    ],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@apollo/client": "^3.8.6",
         "@apollo/experimental-nextjs-app-support": "^0.5.0",
         "@hookform/resolvers": "^3.3.2",
+        "currency-symbol-map": "^5.1.0",
         "graphql": "^16.8.1",
         "next": "13.5.6",
         "react": "18.2.0",
@@ -3970,6 +3971,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
+    },
+    "node_modules/currency-symbol-map": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-5.1.0.tgz",
+      "integrity": "sha512-LO/lzYRw134LMDVnLyAf1dHE5tyO6axEFkR3TXjQIOmMkAM9YL6QsiUwuXzZAmFnuDJcs4hayOgyIYtViXFrLw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -11810,6 +11816,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
+    },
+    "currency-symbol-map": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-5.1.0.tgz",
+      "integrity": "sha512-LO/lzYRw134LMDVnLyAf1dHE5tyO6axEFkR3TXjQIOmMkAM9YL6QsiUwuXzZAmFnuDJcs4hayOgyIYtViXFrLw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@apollo/client": "^3.8.6",
     "@apollo/experimental-nextjs-app-support": "^0.5.0",
     "@hookform/resolvers": "^3.3.2",
+    "currency-symbol-map": "^5.1.0",
     "graphql": "^16.8.1",
     "next": "13.5.6",
     "react": "18.2.0",

--- a/sections/Summary/Summary.tsx
+++ b/sections/Summary/Summary.tsx
@@ -1,0 +1,81 @@
+import classNames from "classnames";
+import getSymbolFromCurrency from "currency-symbol-map";
+import Image from "next/image";
+import React from "react";
+
+import { Checkout, Money } from "@/generated/graphql";
+
+import { SummaryForMobile } from "./SummaryForMobile";
+
+interface SummaryProps {
+  checkoutData: Checkout;
+}
+
+export const Summary = ({ checkoutData }: SummaryProps) => {
+  const quantity = checkoutData.lines[0].quantity;
+  const productPrice = checkoutData.lines[0].totalPrice.net;
+  const productName = checkoutData.lines[0].variant.product.attributes[0].attribute?.name;
+  const thumbnailUrl = checkoutData.lines[0].variant.media?.[0].url;
+  const firstShippingMethodPrice = checkoutData.shippingMethods?.[0].price;
+  const tax = checkoutData.totalPrice.tax;
+  const totalPrice = checkoutData.totalPrice.gross;
+
+  const sharedContent = (
+    <>
+      <div className="mb-5 flex justify-between">
+        <Image
+          className="rounded-md border border-black"
+          src={thumbnailUrl || ""}
+          width={104}
+          height={104}
+          alt="product thumbnail"
+        />
+        <div className="text-lg font-normal">{displayMoney(productPrice)}</div>
+      </div>
+      <div className="mb-5 text-lg font-normal">
+        <div>{productName}</div>
+      </div>
+      <hr className="border-darkGray" />
+      <div className="mb-5 mt-5 flex justify-between text-lg font-normal">
+        <div>Shipping</div>
+        <div>
+          {firstShippingMethodPrice?.amount ? (
+            <>{displayMoney(firstShippingMethodPrice)}</>
+          ) : (
+            <span className="text-lightGray">To be determined</span>
+          )}
+        </div>
+      </div>
+      {!!tax.amount && (
+        <div className="mb-5 flex justify-between text-lg font-normal">
+          <div>Incl VAT</div>
+          <div>{displayMoney(tax)}</div>
+        </div>
+      )}
+      <hr className="border-darkGray" />
+      <div className="mt-5 flex justify-between text-lg font-normal">
+        <div className="self-end">Total</div>
+        <div className="text-4xl">{displayMoney(totalPrice)}</div>
+      </div>
+    </>
+  );
+
+  return (
+    <>
+      <div className={classNames("mb-5 hidden w-full max-w-xs md:block")}>
+        <div className="w-full max-w-full md:max-w-xs">
+          <div className="mb-5 text-lg font-bold">Summary</div>
+          {sharedContent}
+        </div>
+      </div>
+      <SummaryForMobile sharedContent={sharedContent} quantity={quantity} totalPrice={totalPrice} />
+    </>
+  );
+};
+
+export const displayMoney = (data: Money) => (
+  <>
+    {getSymbolFromCurrency(data.currency)}
+    {data.amount}
+  </>
+);

--- a/sections/Summary/SummaryForMobile.tsx
+++ b/sections/Summary/SummaryForMobile.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import classNames from "classnames";
+import Image from "next/image";
+import React, { useState } from "react";
+
+import { Money } from "@/generated/graphql";
+
+import { displayMoney } from ".";
+
+interface SummaryForMobileProps {
+  sharedContent: React.ReactNode;
+  quantity: number;
+  totalPrice: Money;
+}
+
+export const SummaryForMobile = ({ sharedContent, quantity, totalPrice }: SummaryForMobileProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div
+      className={classNames("relative mb-5 block w-full max-w-full rounded-md border border-normalGray p-6 md:hidden")}
+    >
+      <Image
+        className={classNames("absolute right-6 top-6 cursor-pointer md:hidden", {
+          "rotate-0": isOpen,
+          "rotate-180": !isOpen,
+        })}
+        src="/arrow.svg"
+        alt="arrow"
+        width="12"
+        height="12"
+        onClick={() => {
+          setIsOpen(val => !val);
+        }}
+      />
+      <div className="w-full max-w-full md:max-w-xs">
+        <div className="mb-5 text-lg font-normal">Summary</div>
+        {isOpen ? (
+          sharedContent
+        ) : (
+          <div className="mt-5 break-words text-xs text-normalGray">
+            {quantity} {quantity > 1 ? "products:" : "product:"}
+            {displayMoney(totalPrice)}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/sections/Summary/index.ts
+++ b/sections/Summary/index.ts
@@ -1,0 +1,1 @@
+export * from "./Summary";

--- a/sections/index.ts
+++ b/sections/index.ts
@@ -1,1 +1,3 @@
 export * from "./ContactDetails";
+export * from "./ShippingAddress";
+export * from "./Summary";


### PR DESCRIPTION
# CH-05 Create the summary section.

In the following task https://github.com/damian-lis/checkout-flow/pull/5, we implemented the shipping address section at the '/checkout/:checkoutId' page.

Having this section implemented we can start implementing the summary section to show a user some calculations regarding the checkout.

Refer to the following mockups for visual guidance:
https://www.figma.com/file/p6b1WfnP14RjFhw5JbU4Tc/Untitled?node-id=2%3A35&mode=dev

**ACs:**

- the summary section exists on the checkout page at '/checkout/:checkoutId'
- data is presented according to the checkout information
    - shipping, VAT, and total amounts are calculated dynamically (they are changed accordingly to the shipping address updates)
- the section can be expanded or collapsed on mobile sizes only
    - when collapsed, it shows the number of products and their total price
    - when expanded, users can edit the shipping address details

**Potential problems**:

- making the section reactive to the changes provided in the shipping address section.

**Time estimation: 180 min**

- creating UI (60 min)
- creating logic (120 min)

**Result:**
- everything was done within the estimated time.
