### PR TITLE
CH-09 Use server actions (created during development)

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,0 +1,174 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { DEFAULT_CHANNEL } from "@/constants";
+import {
+  AddressInput,
+  CheckoutBillingAddressUpdateDocument,
+  CheckoutCompleteDocument,
+  CheckoutCreateDocument,
+  CheckoutDeliveryMethodUpdateDocument,
+  CheckoutDocument,
+  CheckoutEmailUpdateDocument,
+  CheckoutMetadataUpdateDocument,
+  CheckoutPaymentCreateDocument,
+  CheckoutShippingAddressUpdateDocument,
+  MetadataInput,
+} from "@/generated/graphql";
+import { getClient } from "@/lib/ApolloClient";
+
+export const updateEmail = async (email: string, checkoutId: string) => {
+  const client = getClient();
+
+  const { data, errors } = await client.mutate({
+    mutation: CheckoutEmailUpdateDocument,
+    variables: {
+      email,
+      id: checkoutId,
+    },
+  });
+
+  revalidatePath(`/checkout/${checkoutId}`);
+
+  return { data, errors };
+};
+
+export const updateName = async (name: string, checkoutId: string) => {
+  const client = getClient();
+
+  const { data, errors } = await client.mutate({
+    mutation: CheckoutMetadataUpdateDocument,
+    variables: {
+      input: [
+        {
+          key: "name",
+          value: name,
+        },
+      ],
+      id: checkoutId,
+    },
+  });
+
+  revalidatePath(`/checkout/${checkoutId}`);
+
+  return {
+    data,
+    errors,
+  };
+};
+
+export const updateShippingAddress = async (shippingAddress: AddressInput, checkoutId: string) => {
+  const client = getClient();
+
+  const { data, errors } = await client.mutate({
+    mutation: CheckoutShippingAddressUpdateDocument,
+    variables: {
+      id: checkoutId,
+      shippingAddress,
+    },
+  });
+
+  revalidatePath(`/checkout/${checkoutId}`);
+
+  return {
+    data,
+    errors,
+  };
+};
+
+export const updateDeliveryMethod = async (deliveryMethodId: string, checkoutId: string) => {
+  const client = getClient();
+
+  const { data, errors } = await client.mutate({
+    mutation: CheckoutDeliveryMethodUpdateDocument,
+    variables: {
+      id: checkoutId,
+      deliveryMethodId,
+    },
+  });
+
+  revalidatePath(`/checkout/${checkoutId}`);
+
+  return {
+    data,
+    errors,
+  };
+};
+
+export const updateBillingAddress = async (billingAddress: AddressInput, checkoutId: string) => {
+  const client = getClient();
+
+  const { data, errors } = await client.mutate({
+    mutation: CheckoutBillingAddressUpdateDocument,
+    variables: {
+      id: checkoutId,
+      billingAddress,
+    },
+  });
+
+  return {
+    data,
+    errors,
+  };
+};
+
+export const paymentCreate = async (amount: number, gateway: string, token: string, checkoutId: string) => {
+  const client = getClient();
+
+  const { data, errors } = await client.mutate({
+    mutation: CheckoutPaymentCreateDocument,
+    variables: {
+      checkoutId: checkoutId,
+      input: {
+        amount,
+        gateway,
+        token,
+      },
+    },
+  });
+
+  return {
+    data,
+    errors,
+  };
+};
+
+export const checkoutComplete = async (metadata: MetadataInput[], checkoutId: string) => {
+  const client = getClient();
+
+  const { data, errors } = await client.mutate({
+    mutation: CheckoutCompleteDocument,
+    variables: {
+      checkoutId: checkoutId,
+      metadata,
+    },
+  });
+
+  return {
+    data,
+    errors,
+  };
+};
+
+export const checkoutCreate = async () => {
+  const client = getClient();
+
+  const { data, errors } = await client.mutate({
+    mutation: CheckoutCreateDocument,
+    variables: {
+      channel: DEFAULT_CHANNEL,
+      lines: [{ quantity: 1, variantId: "UHJvZHVjdFZhcmlhbnQ6Mzg0" }],
+    },
+    context: {
+      fetchOptions: {
+        next: { revalidate: 0 },
+      },
+    },
+  });
+
+  return {
+    data,
+    errors,
+  };
+};

--- a/app/checkout/[checkoutId]/page.tsx
+++ b/app/checkout/[checkoutId]/page.tsx
@@ -18,14 +18,7 @@ const CheckoutPage = async ({ params: { checkoutId } }: CheckoutPageProps) => {
     variables: {
       id: checkoutId,
     },
-    context: {
-      fetchOptions: {
-        next: { revalidate: 0 },
-      },
-    },
   });
-
-  // INFO: Potential errors are handled in the 'error.tsx' file
 
   const checkoutData = data.checkout as CheckoutFieldsFragment;
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,52 +1,45 @@
 "use client";
 
-import { useMutation } from "@apollo/client";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useTransition } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components";
-import { DEFAULT_CHANNEL } from "@/constants";
-import { CheckoutCreateDocument } from "@/generated/graphql";
+
+import { checkoutCreate } from "./actions";
 
 const Home = () => {
   const router = useRouter();
-  const [createCheckout, { data, loading, error }] = useMutation(CheckoutCreateDocument);
+  const [pending, startTransition] = useTransition();
 
-  const checkoutId = data?.checkoutCreate?.checkout?.id;
-  const checkoutCreating = !error && (!!checkoutId || loading);
+  const handleCheckoutCreate = async () => {
+    startTransition(async () => {
+      const { data, errors } = await checkoutCreate();
 
-  const handleCheckoutCreate = () => {
-    createCheckout({
-      variables: {
-        channel: DEFAULT_CHANNEL,
-        lines: [{ quantity: 1, variantId: "UHJvZHVjdFZhcmlhbnQ6Mzg0" }],
-      },
-      onCompleted: data => {
-        const errorMessage = data.checkoutCreate?.errors[0]?.message;
-        if (errorMessage)
-          toast.error("Error while creating a checkout", {
-            description: errorMessage,
-          });
-      },
-      onError: ({ message }) => {
+      if (errors?.length) {
         toast.error("Error while creating a checkout", {
-          description: message,
+          description: errors[0].message,
         });
-      },
+        return;
+      }
+
+      const errorMessage = data?.checkoutCreate?.errors[0]?.message;
+
+      if (errorMessage || !data?.checkoutCreate?.checkout?.id) {
+        toast.error("Error while creating a checkout", {
+          description: errorMessage,
+        });
+
+        return;
+      }
+
+      router.push(`/checkout/${data?.checkoutCreate?.checkout?.id}`);
     });
   };
 
-  useEffect(() => {
-    if (!checkoutId) return;
-    router.push(`/checkout/${checkoutId}`);
-  }, [data, router, checkoutId]);
-
-  // INFO: The 404 page is handled in the 'not-found.tsx' file
-
   return (
     <main className="flex h-screen items-center justify-center">
-      <Button size="big" loading={checkoutCreating} disabled={checkoutCreating} onClick={handleCheckoutCreate}>
+      <Button size="big" loading={pending} disabled={pending} onClick={handleCheckoutCreate}>
         Create checkout and add product
       </Button>
     </main>

--- a/graphql/mutations/CheckoutDeliveryMethodUpdate.graphql
+++ b/graphql/mutations/CheckoutDeliveryMethodUpdate.graphql
@@ -1,5 +1,10 @@
+#import "../fragments/CheckoutFields.graphql"
+
 mutation CheckoutDeliveryMethodUpdate($deliveryMethodId: ID!, $id: ID!) {
   checkoutDeliveryMethodUpdate(deliveryMethodId: $deliveryMethodId, id: $id) {
+    checkout {
+      ...CheckoutFields
+    }
     errors {
       field
       message

--- a/graphql/mutations/CheckoutEmailUpdate.graphql
+++ b/graphql/mutations/CheckoutEmailUpdate.graphql
@@ -1,5 +1,10 @@
+#import "../fragments/CheckoutFields.graphql"
+
 mutation CheckoutEmailUpdate($email: String!, $id: ID) {
   checkoutEmailUpdate(email: $email, id: $id) {
+    checkout {
+      ...CheckoutFields
+    }
     errors {
       field
       message

--- a/graphql/mutations/CheckoutMetadataUpdate.graphql
+++ b/graphql/mutations/CheckoutMetadataUpdate.graphql
@@ -1,5 +1,13 @@
+#import "../fragments/CheckoutFields.graphql"
+
 mutation CheckoutMetadataUpdate($id: ID!, $input: [MetadataInput!]!) {
   updateMetadata(id: $id, input: $input) {
+    item {
+      metadata {
+        key
+        value
+      }
+    }
     errors {
       field
       message

--- a/graphql/mutations/CheckoutShippingAddressUpdate.graphql
+++ b/graphql/mutations/CheckoutShippingAddressUpdate.graphql
@@ -1,10 +1,9 @@
+#import "../fragments/CheckoutFields.graphql"
+
 mutation CheckoutShippingAddressUpdate($id: ID!, $shippingAddress: AddressInput!) {
   checkoutShippingAddressUpdate(id: $id, shippingAddress: $shippingAddress) {
     checkout {
-      id
-      shippingMethods {
-        id
-      }
+      ...CheckoutFields
     }
     errors {
       field

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 
 module.exports = {
+  experimental: {
+    serverActions: {
+      allowedOrigins: ["*"],
+    },
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
# CH-09 Use server actions.

After some thought, I came up with an idea to use server actions to get section data and update checkout to get the most from the Next JS v13 features.

_I didn't use it before since I was not sure how I could integrate it with React Hook Form (I took a safer way to get the job done within the estimated time)._

**ACs:**
- use server actions to mutate and query checkout data.

**Expected time: 120min**

**Result:**
- I did the update within the expected time but unfortunately didn't achieve what I wanted initially (I don't know how to revalidate the path without triggering fetching checkout data again). So the result is what I tried to fix here: https://github.com/damian-lis/checkout-flow/pull/11. 

With the server actions though I feel that the code is more readable and only solving the problem of refetching checkout data will provide the UX I really wanted (without lagging).